### PR TITLE
feat: new background design settings and fix layouts #13

### DIFF
--- a/components/base/Skeleton/index.tsx
+++ b/components/base/Skeleton/index.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/react';
+
+interface Props {
+  width?: number;
+  height?: number;
+  circle?: boolean; // 원형 스켈레톤 true or false
+  rounded?: boolean; // border-rounded true or false
+  count?: number; // width, height 지정되어 있지 않고 inline일 때, 글자의 개수
+  unit?: string; //  픽셀이나 퍼센트 등의 단위
+  animation?: boolean; // 애니메이션 유무
+  color?: string; // 스켈레톤의 배경색
+  style?: React.CSSProperties; // 추가적인 스타일링 객체
+  children?: React.ReactNode;
+}
+
+const pulseKeyframe = keyframes`
+  0%{
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const pulseAnimation = css`
+  animation: ${pulseKeyframe} 1.5s ease-in-out infinite;
+`;
+
+const Base = styled.div<Props>`
+  ${({ color }) => color && `background-color: ${color}`};
+  ${({ rounded }) => rounded && 'border-radius: 8px'};
+  ${({ circle }) => circle && 'border-radius: 50%'};
+  ${({ width, height }) => (width || height) && 'display: block'};
+  ${({ animation }) => animation && pulseAnimation};
+  width: ${({ width, unit }) => width && unit && `${width}${unit}`};
+  height: ${({ height, unit }) => height && unit && `${height}${unit}`};
+`;
+
+const Content = styled.span`
+  opacity: 0;
+`;
+
+const Skeleton: React.FC<Props> = ({
+  animation = true,
+  children,
+  width,
+  height,
+  circle,
+  rounded,
+  count,
+  unit = 'px',
+  color = '#F4F4F4',
+  style,
+}) => {
+  // count 4 => '----'
+  // count 6 => '----'
+  const content = useMemo(
+    () => [...Array({ length: count })].map(() => '-').join(''),
+    [count],
+  );
+
+  return (
+    <Base
+      style={style}
+      rounded={rounded}
+      circle={circle}
+      width={width}
+      height={height}
+      animation={animation}
+      unit={unit}
+      color={color}
+    >
+      <Content>{children || content}</Content>
+    </Base>
+  );
+};
+
+export default Skeleton;

--- a/components/base/index.ts
+++ b/components/base/index.ts
@@ -4,5 +4,6 @@ export { default as Portal } from './Portal';
 export { default as Button } from './Button';
 export { default as Header } from './Header';
 export { default as Footer } from './Footer';
+export { default as Skeleton } from './Skeleton';
 export { default as FloatingButton } from './FloatingButton';
 export { default as DeferredComponent } from './DeferredComponent';

--- a/components/base/input/index.tsx
+++ b/components/base/input/index.tsx
@@ -12,82 +12,12 @@ import { textStyle } from '@styles/mixins/_text-style';
 // don't deal with events
 // easier inputs
 
-interface InputProps {
-  label: string;
-  labelHidden?: boolean;
-  name: string;
-  kind?: 'text' | 'phone' | 'price';
-  register: UseFormRegisterReturn;
-  required: boolean;
-  type: string;
-  placeholder?: string;
-}
-
-export default function Input({
-  label,
-  labelHidden = false,
-  name,
-  kind = 'text',
-  register,
-  type,
-  required,
-  placeholder,
-}: InputProps) {
-  return (
-    <Base>
-      <Label htmlFor={name} className={labelHidden ? 'visually-hidden' : ''}>
-        {label}
-      </Label>
-      {kind === 'text' ? (
-        <Wrapper>
-          <InputStyled
-            id={name}
-            required={required}
-            autoComplete="off"
-            {...register}
-            type={type}
-            placeholder={placeholder}
-          />
-        </Wrapper>
-      ) : null}
-      {kind === 'price' ? (
-        <Wrapper>
-          <InputStyled
-            id={name}
-            required={required}
-            autoComplete="off"
-            {...register}
-            type={type}
-            placeholder={placeholder}
-          />
-          <Currency>
-            <span>KRW</span>
-          </Currency>
-        </Wrapper>
-      ) : null}
-      {kind === 'phone' ? (
-        <PhoneWrapper>
-          <CountryCode>+82</CountryCode>
-          <InputStyled
-            id={name}
-            required={required}
-            autoComplete="off"
-            {...register}
-            type={type}
-            placeholder={placeholder}
-          />
-        </PhoneWrapper>
-      ) : null}
-    </Base>
-  );
-}
-
 const Base = styled.div``;
 
 const Label = styled.label`
   display: block;
   margin-bottom: 0.25rem;
-  ${textStyle(14, 'rgb(55 65 81)')};
+  ${textStyle(14, '#8B95A1')};
   font-weight: 500;
 `;
 
@@ -95,22 +25,34 @@ const Wrapper = styled.div`
   position: relative;
   display: flex;
   align-items: center;
-  border-radius: 6px;
 `;
 
 const InputStyled = styled.input`
   width: 100%;
   appearance: none;
-  border: 1px solid lightgray;
-  border-radius: 6px;
-  padding: 10px 12px;
-  background-color: #fff;
-  box-shadow: 0 4px 20px rgba(63, 65, 80, 0.3);
-  &:focus {
-    border-color: rgb(55 65 81, 0.7);
+  border-bottom: 1.5px solid lightgray;
+  padding: 2px;
+  ${textStyle(18, '#191e29')}
+
+  /* Chrome, Safari, Edge, Opera */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
   }
+
+  /* Firefox */
+  &[type='number'] {
+    -moz-appearance: textfield;
+  }
+
+  &:focus {
+    /* border-color: rgb(55 65 81, 0.7); */
+  }
+
   &::placeholder {
-    color: rgb(156 163 175);
+    /* color: rgb(156 163 175); */
+    ${textStyle(18, '#191e29')}
   }
 `;
 
@@ -120,9 +62,10 @@ const Currency = styled.div`
   pointer-events: none;
   display: flex;
   align-items: center;
-  padding-right: 0.75rem;
+  padding-right: 2px;
+
   > span {
-    color: rgb(107 114 128);
+    ${textStyle(18, '#191e29')}
   }
 `;
 
@@ -144,3 +87,76 @@ const CountryCode = styled.span`
   background-color: rgb(249 250 251);
   user-select: none;
 `;
+
+interface InputProps {
+  name: string;
+  register: UseFormRegisterReturn;
+  type?: string;
+  label?: string;
+  required?: boolean;
+  labelHidden?: boolean;
+  placeholder?: string;
+  kind?: 'text' | 'phone' | 'price';
+  onKeyUp?: () => void;
+}
+
+export default function Input({
+  name,
+  register,
+  type = 'text',
+  label,
+  required = true,
+  labelHidden = false,
+  placeholder,
+  kind = 'text',
+  onKeyUp,
+}: InputProps) {
+  return (
+    <Base>
+      <Label htmlFor={name} className={labelHidden ? 'visually-hidden' : ''}>
+        {label || name}
+      </Label>
+      {kind === 'text' ? (
+        <Wrapper>
+          <InputStyled
+            id={name}
+            // required={required}
+            autoComplete="off"
+            {...register}
+            type={type}
+            placeholder={placeholder}
+          />
+        </Wrapper>
+      ) : null}
+      {kind === 'price' ? (
+        <Wrapper>
+          <InputStyled
+            id={name}
+            required={required}
+            autoComplete="off"
+            {...register}
+            type={type}
+            placeholder={placeholder}
+            onKeyUp={onKeyUp}
+          />
+          <Currency>
+            <span>원</span>
+          </Currency>
+        </Wrapper>
+      ) : null}
+      {kind === 'phone' ? (
+        <PhoneWrapper>
+          <CountryCode>+82</CountryCode>
+          <InputStyled
+            id={name}
+            required={required}
+            autoComplete="off"
+            {...register}
+            type={type}
+            placeholder={placeholder}
+          />
+        </PhoneWrapper>
+      ) : null}
+    </Base>
+  );
+}

--- a/components/layout/GoBack/index.tsx
+++ b/components/layout/GoBack/index.tsx
@@ -3,6 +3,26 @@ import { useRouter } from 'next/router';
 
 import { flexbox } from '@styles/mixins/_flexbox';
 
+const Base = styled.div`
+  position: fixed;
+  max-width: 640px;
+  width: 100%;
+  height: 3rem;
+  background-color: #fff;
+  ${flexbox('start', 'center')}
+`;
+
+const Button = styled.button`
+  display: inline-block;
+  padding-left: 0.8rem;
+
+  > svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: #74747b;
+  }
+`;
+
 interface BackProps {
   path?: string;
   currying?: () => void;
@@ -38,24 +58,3 @@ function GoBack({ path, currying }: BackProps) {
 }
 
 export default GoBack;
-
-const Base = styled.div`
-  position: fixed;
-  top: 0;
-  max-width: 640px;
-  width: 100%;
-  height: 3rem;
-  background-color: #fff;
-  ${flexbox('start', 'center')}
-`;
-
-const Button = styled.button`
-  display: inline-block;
-  padding-left: 0.8rem;
-
-  > svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    color: #74747b;
-  }
-`;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,25 @@
+import Link from 'next/link';
 import { useEffect } from 'react';
-import type { NextPage } from 'next';
 import styled from '@emotion/styled';
+import type { NextPage } from 'next';
 import { useSetRecoilState } from 'recoil';
 
 import { Button } from '@components/base';
+import { canGoBack } from '@recoil/layout/navigator';
 import { LandingBox } from '@components/domain/home';
 import { columnFlexbox } from '@styles/mixins/_flexbox';
 
-import { canGoBack } from '@recoil/layout/navigator';
+const Main = styled.main`
+  ${columnFlexbox('around', 'center')};
+  row-gap: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 15px;
+
+  > a {
+    width: 100%;
+  }
+`;
 
 const Home: NextPage = () => {
   const setCanGoBack = useSetRecoilState(canGoBack);
@@ -21,20 +33,16 @@ const Home: NextPage = () => {
     <>
       <Main>
         <LandingBox />
-        <Button>펀딩 만들기</Button>
+        <Link href="/">
+          <a aria-hidden>
+            <Button type="button" aria-label="펀딩 생성 버튼">
+              펀딩 만들기
+            </Button>
+          </a>
+        </Link>
       </Main>
     </>
   );
 };
 
 export default Home;
-
-const Main = styled.main`
-  width: 100%;
-  height: 50%;
-  ${columnFlexbox('between', 'center')};
-  row-gap: 12px;
-  padding: 0 10px;
-  margin-top: 15rem;
-  font-weight: 700;
-`;

--- a/public/assets/images/background.svg
+++ b/public/assets/images/background.svg
@@ -1,0 +1,50 @@
+<svg width="360" height="800" viewBox="0 0 360 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="360" height="800" fill="white"/>
+<mask id="mask0_262_657" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="360" height="800">
+<rect width="360" height="800" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_262_657)">
+<g filter="url(#filter0_f_262_657)">
+<ellipse cx="108.699" cy="43.5284" rx="131.795" ry="174.161" fill="#E6F6FF"/>
+</g>
+<g filter="url(#filter1_f_262_657)">
+<path d="M438.663 375.445C438.663 512.232 354.964 623.12 251.715 623.12C148.467 623.12 64.7676 512.232 64.7676 375.445C64.7676 238.658 148.467 127.77 251.715 127.77C354.964 127.77 438.663 238.658 438.663 375.445Z" fill="#E6F6FF"/>
+</g>
+<g filter="url(#filter2_f_262_657)">
+<path d="M383.271 22.7045C383.271 105.822 332.389 173.203 269.622 173.203C206.856 173.203 155.973 105.822 155.973 22.7045C155.973 -60.4133 206.856 -127.794 269.622 -127.794C332.389 -127.794 383.271 -60.4133 383.271 22.7045Z" fill="#FFFBA7"/>
+</g>
+<g filter="url(#filter3_f_262_657)">
+<ellipse cx="134.724" cy="627.221" rx="148.269" ry="195.932" fill="#FFFBA7"/>
+</g>
+<g filter="url(#filter4_f_262_657)">
+<ellipse cx="64.2901" cy="229.995" rx="103.621" ry="136.931" fill="#FFFBA7"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_262_657" x="-147.095" y="-254.633" width="511.589" height="596.323" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="62" result="effect1_foregroundBlur_262_657"/>
+</filter>
+<filter id="filter1_f_262_657" x="-59.2324" y="3.76959" width="621.896" height="743.35" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="62" result="effect1_foregroundBlur_262_657"/>
+</filter>
+<filter id="filter2_f_262_657" x="31.9731" y="-251.794" width="475.298" height="548.996" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="62" result="effect1_foregroundBlur_262_657"/>
+</filter>
+<filter id="filter3_f_262_657" x="-137.545" y="307.29" width="544.538" height="639.863" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="62" result="effect1_foregroundBlur_262_657"/>
+</filter>
+<filter id="filter4_f_262_657" x="-163.331" y="-30.9366" width="455.242" height="521.862" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="62" result="effect1_foregroundBlur_262_657"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
- new backgournd design setting
- add divider in only homepage
  - 현재는 PATH === 'Home' 일때만 보이게끔 해놨습니다.
  - 추후 상태관리에 편리하게 제작해놨습니다.
- add common Input component ui 
  - onClick
  - onKeyUp
  - {...register}
  - {...rest} 
- add common Skeleton component ui 